### PR TITLE
feat: enhance subscription toggle functionality with latest event delivery toggle.

### DIFF
--- a/Panoptes.Client/src/components/SubscriptionCard.tsx
+++ b/Panoptes.Client/src/components/SubscriptionCard.tsx
@@ -38,7 +38,8 @@ export const SubscriptionCard: React.FC<SubscriptionCardProps> = ({
     currentStatus = 'active';
   }
 
-  const handleToggle = async () => {
+  const handleToggle = async (e: React.MouseEvent) => {
+    e.stopPropagation(); // Prevent card navigation
     if (isDisabled || isToggling) return;
     setIsToggling(true);
     try {
@@ -48,7 +49,8 @@ export const SubscriptionCard: React.FC<SubscriptionCardProps> = ({
     }
   };
 
-  const handleReset = async () => {
+  const handleReset = async (e: React.MouseEvent) => {
+    e.stopPropagation(); // Prevent card navigation
     if (!onReset || isResetting) return;
     setIsResetting(true);
     try {
@@ -236,7 +238,7 @@ export const SubscriptionCard: React.FC<SubscriptionCardProps> = ({
           className="p-2 bg-white/80 hover:bg-white text-indigo-600 rounded-lg shadow-sm hover:shadow transition-colors"
           title="Test Webhook"
         >
-          <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><polygon points="5 3 19 12 5 21 5 3" /></svg>
+          <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M22 2L11 13"/><path d="M22 2L15 22L11 13L2 9L22 2Z"/></svg>
         </button>
         <button
           onClick={(e) => { e.stopPropagation(); onEdit(subscription.id); }}

--- a/Panoptes.Client/src/services/api.ts
+++ b/Panoptes.Client/src/services/api.ts
@@ -55,8 +55,8 @@ export const deleteSubscription = async (id: string): Promise<void> => {
     await api.delete(`/Subscriptions/${id}`);
 };
 
-export const toggleSubscriptionActive = async (id: string): Promise<WebhookSubscription> => {
-    const response = await api.post<WebhookSubscription>(`/Subscriptions/${id}/toggle`);
+export const toggleSubscriptionActive = async (id: string, deliverLatestOnly: boolean = false): Promise<WebhookSubscription> => {
+    const response = await api.post<WebhookSubscription>(`/Subscriptions/${id}/toggle?deliverLatestOnly=${deliverLatestOnly}`);
     return response.data;
 };
 


### PR DESCRIPTION
This pull request adds a new feature that allows users to control webhook delivery behavior when resuming a paused subscription, specifically by choosing to deliver only the latest halted event or all pending events. The implementation spans both backend and frontend, introducing a new API parameter, updating UI controls, and persisting user preferences.

### Backend: Subscription Toggle API enhancements
* Added a `deliverLatestOnly` query parameter to the `ToggleSubscription` endpoint in `SubscriptionsController.cs`, allowing clients to specify if only the latest halted event should be delivered upon resuming a subscription.
* Updated the logic in `ToggleSubscription` so that, when `deliverLatestOnly` is true, only the most recent paused event is queued for delivery and all others are marked as discarded; otherwise, all paused events are queued.

### Frontend: UI and API integration
* Added a "Latest Only" toggle in `SubscriptionDetail.tsx` that lets users control the delivery mode when resuming a paused subscription. The preference is persisted to localStorage per subscription. [[1]](diffhunk://#diff-895f05c781dc9586e6133e5bcf1579795723da92a16529c6e3fe6a9d6dc218afR59-R79) [[2]](diffhunk://#diff-895f05c781dc9586e6133e5bcf1579795723da92a16529c6e3fe6a9d6dc218afL367-R442)
* Updated the API service function `toggleSubscriptionActive` in `api.ts` to accept and forward the `deliverLatestOnly` parameter to the backend.
* Modified the resume/toggle logic in `SubscriptionDetail.tsx` to use the new API parameter and refresh subscription state after toggling. [[1]](diffhunk://#diff-895f05c781dc9586e6133e5bcf1579795723da92a16529c6e3fe6a9d6dc218afL182-R213) [[2]](diffhunk://#diff-895f05c781dc9586e6133e5bcf1579795723da92a16529c6e3fe6a9d6dc218afL253-R276)

### Usability and UI improvements
* Updated event handling in `SubscriptionCard.tsx` to prevent unintended navigation when toggling or resetting a subscription. [[1]](diffhunk://#diff-5b5b51cefcb3b26973ed9681460c0d3900b47e360b49e718b601a85042fd9054L41-R42) [[2]](diffhunk://#diff-5b5b51cefcb3b26973ed9681460c0d3900b47e360b49e718b601a85042fd9054L51-R53)
* Improved button icons and layout for better clarity and consistency in both `SubscriptionCard.tsx` and `SubscriptionDetail.tsx`. [[1]](diffhunk://#diff-5b5b51cefcb3b26973ed9681460c0d3900b47e360b49e718b601a85042fd9054L239-R241) [[2]](diffhunk://#diff-895f05c781dc9586e6133e5bcf1579795723da92a16529c6e3fe6a9d6dc218afL341-R374)

---

**References:** [[1]](diffhunk://#diff-9c7851b678e6f2cd1e43f399f992e6e02e1f759ad4af1e1b78f87eeb09d7238fR501-R504) [[2]](diffhunk://#diff-9c7851b678e6f2cd1e43f399f992e6e02e1f759ad4af1e1b78f87eeb09d7238fL520-R548) [[3]](diffhunk://#diff-895f05c781dc9586e6133e5bcf1579795723da92a16529c6e3fe6a9d6dc218afR59-R79) [[4]](diffhunk://#diff-895f05c781dc9586e6133e5bcf1579795723da92a16529c6e3fe6a9d6dc218afL367-R442) [[5]](diffhunk://#diff-1329e1c5aab12571791e94b95e8df399794f71bd56d7d930234f1885ef29c635L58-R59)

This pull request closes #76 , #71 , and #58 