### PR TITLE
Add comprehensive subscription state management system with three states

### DIFF
--- a/Panoptes.Client/package-lock.json
+++ b/Panoptes.Client/package-lock.json
@@ -116,7 +116,6 @@
       "version": "6.15.0",
       "resolved": "https://registry.npmjs.org/@aws-amplify/core/-/core-6.15.0.tgz",
       "integrity": "sha512-D08O7GaF6bDcwhKBkSURus5vJGdaNrTeIEZk9OQiDe3jiR1HOiNq7djIZXUWLc3FuiJ1Yhf2aHTD9/Gj6fqQxw==",
-      "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-js": "5.2.0",
         "@aws-sdk/types": "3.398.0",
@@ -603,7 +602,6 @@
       "version": "3.621.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.621.0.tgz",
       "integrity": "sha512-mMjk3mFUwV2Y68POf1BQMTF+F6qxt5tPu6daEUCNGC9Cenk3h2YXQQoS4/eSyYzuBiYk3vx49VgleRvdvkg8rg==",
-      "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
@@ -704,7 +702,6 @@
       "version": "3.621.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.621.0.tgz",
       "integrity": "sha512-707uiuReSt+nAx6d0c21xLjLm2lxeKc7padxjv92CIrIocnQSlJPxSCM7r5zBhwiahJA6MNQwmTl2xznU67KgA==",
-      "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
@@ -1337,7 +1334,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -4032,7 +4028,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.27.tgz",
       "integrity": "sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -4055,7 +4050,6 @@
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -4099,7 +4093,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4389,7 +4382,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4651,8 +4643,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/d3-array": {
       "version": "3.2.4",
@@ -5019,7 +5010,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -5833,7 +5823,6 @@
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -6382,7 +6371,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -6588,7 +6576,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -6641,7 +6628,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -7284,7 +7270,6 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.18.tgz",
       "integrity": "sha512-6A2rnmW5xZMdw11LYjhcI5846rt9pbLSabY5XPxo+XWdxwZaFEn47Go4NzFiHu9sNNmr/kXivP1vStfvMaK1GQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -7398,7 +7383,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7618,7 +7602,6 @@
       "integrity": "sha512-ITcnkFeR3+fI8P1wMgItjGrR10170d8auB4EpMLPqmx6uxElH3a/hHGQabSHKdqd4FXWO1nFIp9rRn7JQ34ACQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -7712,7 +7695,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },

--- a/Panoptes.Client/src/components/AdvancedOptionsModal.tsx
+++ b/Panoptes.Client/src/components/AdvancedOptionsModal.tsx
@@ -1,0 +1,123 @@
+import React from 'react';
+
+interface AdvancedOptionsModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  subscriptionName: string;
+  deliverLatestOnly: boolean;
+  onDeliverLatestOnlyChange: (value: boolean) => void;
+}
+
+const AdvancedOptionsModal: React.FC<AdvancedOptionsModalProps> = ({
+  isOpen,
+  onClose,
+  subscriptionName,
+  deliverLatestOnly,
+  onDeliverLatestOnlyChange,
+}) => {
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 overflow-y-auto">
+      {/* Backdrop */}
+      <div 
+        className="fixed inset-0 bg-black/50 transition-opacity" 
+        onClick={onClose}
+      />
+      
+      {/* Modal */}
+      <div className="flex min-h-full items-center justify-center p-4">
+        <div className="relative bg-white rounded-xl shadow-xl w-full max-w-lg transform transition-all">
+          {/* Header */}
+          <div className="flex items-center justify-between p-6 border-b border-gray-200">
+            <div>
+              <h2 className="text-xl font-bold text-gray-900">Advanced Options</h2>
+              <p className="text-sm text-gray-500 mt-1">{subscriptionName}</p>
+            </div>
+            <button
+              onClick={onClose}
+              className="p-2 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded-lg transition-colors"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/>
+              </svg>
+            </button>
+          </div>
+
+          {/* Content */}
+          <div className="p-6 space-y-6">
+            {/* Delivery Behavior Section */}
+            <div>
+              <h3 className="text-sm font-semibold text-gray-900 uppercase tracking-wide mb-4">
+                Delivery Behavior
+              </h3>
+              
+              {/* Latest Only Toggle */}
+              <div className="bg-gray-50 rounded-lg p-4 border border-gray-200">
+                <div className="flex items-start justify-between gap-4">
+                  <div className="flex-1">
+                    <label className="text-sm font-medium text-gray-900">
+                      Deliver Latest Only
+                    </label>
+                    <p className="text-xs text-gray-500 mt-1">
+                      When resuming from a paused state, only the most recent halted event will be delivered. 
+                      All other queued events will be discarded.
+                    </p>
+                  </div>
+                  <button
+                    type="button"
+                    role="switch"
+                    aria-checked={deliverLatestOnly}
+                    onClick={() => onDeliverLatestOnlyChange(!deliverLatestOnly)}
+                    className={`relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-amber-500 focus:ring-offset-2 ${
+                      deliverLatestOnly ? 'bg-amber-500' : 'bg-gray-300'
+                    }`}
+                  >
+                    <span
+                      className={`pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out ${
+                        deliverLatestOnly ? 'translate-x-5' : 'translate-x-0'
+                      }`}
+                    />
+                  </button>
+                </div>
+                
+                {/* Status indicator */}
+                <div className={`mt-3 text-xs px-2 py-1 rounded inline-flex items-center gap-1 ${
+                  deliverLatestOnly 
+                    ? 'bg-amber-100 text-amber-700' 
+                    : 'bg-green-100 text-green-700'
+                }`}>
+                  <span className={`w-1.5 h-1.5 rounded-full ${
+                    deliverLatestOnly ? 'bg-amber-500' : 'bg-green-500'
+                  }`}/>
+                  {deliverLatestOnly 
+                    ? 'Only latest event will be delivered on resume' 
+                    : 'All queued events will be delivered on resume'}
+                </div>
+              </div>
+            </div>
+
+            {/* Placeholder for future options */}
+            <div className="border-t border-gray-200 pt-4">
+              <p className="text-xs text-gray-400 italic">
+                More advanced options coming soon...
+              </p>
+            </div>
+          </div>
+
+          {/* Footer */}
+          <div className="flex justify-end gap-3 p-6 border-t border-gray-200 bg-gray-50 rounded-b-xl">
+            <button
+              onClick={onClose}
+              className="px-4 py-2 bg-gray-900 text-white text-sm font-medium rounded-lg hover:bg-gray-800 transition-colors"
+            >
+              Done
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default AdvancedOptionsModal;

--- a/Panoptes.Client/src/index.css
+++ b/Panoptes.Client/src/index.css
@@ -67,6 +67,14 @@
   * {
     @apply border-border;
   }
+  
+  /* Smooth dark mode transition */
+  *, *::before, *::after {
+    transition-property: background-color, border-color, color, fill, stroke;
+    transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+    transition-duration: 150ms;
+  }
+  
   body {
     @apply bg-background text-foreground;
     font-feature-settings: "rlig" 1, "calt" 1;


### PR DESCRIPTION
- Active: Normal webhook delivery
- Paused: Manual pause by user, events queued for later delivery
- Disabled: Auto-disabled by rate limiting or circuit breaker

Features:
- Pause/resume toggle directly on subscription cards (clickable status indicator)
- Advanced Options modal for technical settings
- 'Deliver Latest Only' option to control queued event delivery on resume
- Auto-recovery when rate limits drop below 80% threshold
- Events stop being tracked when disabled to allow rate counters to settle
- Seamless state transitions without confirmation dialogs
- State persistence in localStorage per subscription

Backend Changes:
- Added toggle endpoint (POST /Subscriptions/{id}/toggle)
- Added deliverLatestOnly parameter for selective event delivery
- Modified PanoptesReducer to skip disabled subscriptions from blockchain tracking
- Updated WebhookRetryWorker to exclude disabled subscriptions from retries
- Auto-recovery worker checks rate limits every minute

Frontend Changes:
- Clickable status indicators on subscription cards (Active/Paused/Disabled)
- Advanced Options modal component for technical tweaks
- Updated Dashboard, SubscriptionDetail, SubscriptionCard components
- Smooth dark mode transitions (150ms)
- Changed test button icon from play to send (paper plane)

Known Issues (WIP):
- Disabled state needs refinement (circuit breaker vs rate limit distinction)
- Reset functionality needs improvement for different disabled triggers
- Rate counter tracking during disabled state needs verification

Breaking Changes:
- Removed separate freeze/unfreeze endpoints in favor of toggle
- IsPaused removed, using isActive for pause state instead"